### PR TITLE
Fix case in ElectronsFromIonization where material properties are supplied.

### DIFF
--- a/src/kernels/ElectronsFromIonization.C
+++ b/src/kernels/ElectronsFromIonization.C
@@ -43,13 +43,15 @@ ElectronsFromIonization::ElectronsFromIonization(const InputParameters & paramet
 
   if (!(isCoupled("potential")))
     _minus_e_field.resize(_fe_problem.getMaxQps(), RealGradient(-getParam<Real>("EField")));
-  _user_diffem.set().resize(_fe_problem.getMaxQps(), Real(getParam<Real>("diffem")));
-  _user_d_diffem_d_actual_mean_en.set().resize(_fe_problem.getMaxQps(), Real(0));
-  _user_muem.set().resize(_fe_problem.getMaxQps(), Real(getParam<Real>("muem")));
-  _user_d_muem_d_actual_mean_en.set().resize(_fe_problem.getMaxQps(), Real(0));
-  _user_alpha_iz.set().resize(_fe_problem.getMaxQps(), Real(getParam<Real>("alpha_iz")));
-  _user_d_iz_d_actual_mean_en.set().resize(_fe_problem.getMaxQps(), Real(0));
-
+  if (!(getParam<bool>("use_material_props")))
+    {
+      _user_diffem.set().resize(_fe_problem.getMaxQps(), Real(getParam<Real>("diffem")));
+      _user_d_diffem_d_actual_mean_en.set().resize(_fe_problem.getMaxQps(), Real(0));
+      _user_muem.set().resize(_fe_problem.getMaxQps(), Real(getParam<Real>("muem")));
+      _user_d_muem_d_actual_mean_en.set().resize(_fe_problem.getMaxQps(), Real(0));
+      _user_alpha_iz.set().resize(_fe_problem.getMaxQps(), Real(getParam<Real>("alpha_iz")));
+      _user_d_iz_d_actual_mean_en.set().resize(_fe_problem.getMaxQps(), Real(0));
+    }
 }
 
 ElectronsFromIonization::~ElectronsFromIonization()

--- a/tests/1d_dc/mean_en.i
+++ b/tests/1d_dc/mean_en.i
@@ -146,6 +146,7 @@ dom1Scale=1e-7
     variable = em
     potential = potential
     mean_en = mean_en
+    em = em
     block = 0
     position_units = ${dom0Scale}
   [../]

--- a/tests/Drift/Input_Ar_6_um_103_V.i
+++ b/tests/Drift/Input_Ar_6_um_103_V.i
@@ -112,6 +112,7 @@ vhigh = 103E-3 #kV
 	[../]
 	[./em_ionization]
 		type = ElectronsFromIonization
+    em = em
 		variable = em
 		potential = potential
 		mean_en = mean_en

--- a/tests/DriftDiffusion/Input_Ar_6_um_103_V.i
+++ b/tests/DriftDiffusion/Input_Ar_6_um_103_V.i
@@ -112,6 +112,7 @@ vhigh = 103E-3 #kV
 	[../]
 	[./em_ionization]
 		type = ElectronsFromIonization
+    em = em
 		variable = em
 		potential = potential
 		mean_en = mean_en

--- a/tests/Schottky_emission/Input.i
+++ b/tests/Schottky_emission/Input.i
@@ -119,6 +119,7 @@ vhigh = 0.10 #kV
 	[../]
 	[./em_ionization]
 		type = ElectronsFromIonization
+    em = em
 		variable = em
 		potential = potential
 		mean_en = mean_en

--- a/tests/Schottky_emission/Input_Ar_6_um_103_V.i
+++ b/tests/Schottky_emission/Input_Ar_6_um_103_V.i
@@ -119,6 +119,7 @@ vhigh = 103E-3 #kV
 	[../]
 	[./em_ionization]
 		type = ElectronsFromIonization
+    em = em
 		variable = em
 		potential = potential
 		mean_en = mean_en

--- a/tests/Schottky_emission/Schottky_emission.i
+++ b/tests/Schottky_emission/Schottky_emission.i
@@ -117,6 +117,7 @@ vhigh = 0.10 #kV
 	[../]
 	[./em_ionization]
 		type = ElectronsFromIonization
+    em = em
 		variable = em
 		potential = potential
 		mean_en = mean_en

--- a/tests/field_emission/field_emission.i
+++ b/tests/field_emission/field_emission.i
@@ -117,6 +117,7 @@ vhigh=0.15 #kV
 	[../]
 	[./em_ionization]
 		type = ElectronsFromIonization
+    em = em
 		variable = em
 		potential = potential
 		mean_en = mean_en

--- a/tests/reflections/Input.i
+++ b/tests/reflections/Input.i
@@ -119,6 +119,7 @@ vhigh = 103E-3 #kV
 	[../]
 	[./em_ionization]
 		type = ElectronsFromIonization
+    em = em
 		variable = em
 		potential = potential
 		mean_en = mean_en

--- a/tests/thermionic/mean_en.i
+++ b/tests/thermionic/mean_en.i
@@ -117,6 +117,7 @@ vhigh=0.15 #kV
 	[../]
 	[./em_ionization]
 		type = ElectronsFromIonization
+    em = em
 		variable = em
 		potential = potential
 		mean_en = mean_en


### PR DESCRIPTION
If mean_en.i is any indication, all old input files should now work _as long as_ `em = em` is added to the ElectronsFromIonization block.