### PR TITLE
Convert PenaltyCircuitPotential to use the ShapeSideUserObject.

### DIFF
--- a/include/bcs/PenaltyCircuitPotential.h
+++ b/include/bcs/PenaltyCircuitPotential.h
@@ -1,7 +1,9 @@
 #ifndef PENALTYCIRCUITPOTENTIAL_H
 #define PENALTYCIRCUITPOTENTIAL_H
 
-#include "IntegratedBC.h"
+#include "NonlocalIntegratedBC.h"
+#include "CurrentDensityShapeSideUserObject.h"
+#include "ProvideMobility.h"
 
 class PenaltyCircuitPotential;
 
@@ -13,7 +15,7 @@ InputParameters validParams<PenaltyCircuitPotential>();
  *
  * Sets the value at the node to the value of a Postprocessor
  */
-class PenaltyCircuitPotential : public IntegratedBC
+class PenaltyCircuitPotential : public NonlocalIntegratedBC
 {
 public:
   PenaltyCircuitPotential(const InputParameters & parameters);
@@ -21,13 +23,24 @@ public:
 protected:
   virtual Real computeQpResidual();
   virtual Real computeQpJacobian();
+  virtual Real computeQpOffDiagJacobian(unsigned int jvar);
+  virtual Real computeQpNonlocalJacobian(dof_id_type dof_index);
+  virtual Real computeQpNonlocalOffDiagJacobian(unsigned int jvar, dof_id_type dof_index);
 
-  /// The value for this BC
-  const PostprocessorValue & _current;
+
+  const CurrentDensityShapeSideUserObject & _current_uo;
+  const Real & _current;
+  const std::vector<Real> & _current_jac;
   Real _surface_potential;
   std::string _surface;
   Real _current_sign;
   Real _p;
+  const ProvideMobility & _data;
+  const std::vector<dof_id_type> & _var_dofs;
+  unsigned int _em_id;
+  const std::vector<dof_id_type> & _em_dofs;
+  unsigned int _ip_id;
+  const std::vector<dof_id_type> & _ip_dofs;
 };
 
 #endif /* PENALTYCIRCUITPOTENTIAL_H */

--- a/src/bcs/PenaltyCircuitPotential.C
+++ b/src/bcs/PenaltyCircuitPotential.C
@@ -3,21 +3,32 @@
 template<>
 InputParameters validParams<PenaltyCircuitPotential>()
 {
-  InputParameters p = validParams<IntegratedBC>();
-  p.addRequiredParam<PostprocessorName>("current", "The postprocessor response for calculating the current passing through the needle surface.");
+  InputParameters p = validParams<NonlocalIntegratedBC>();
+  p.addRequiredParam<UserObjectName>("current", "The postprocessor response for calculating the current passing through the needle surface.");
   p.addRequiredParam<Real>("surface_potential", "The electrical potential applied to the surface if no current was flowing in the circuit.");
   p.addRequiredParam<std::string>("surface", "Whether you are specifying the potential on the anode or the cathode with the requirement that the other metal surface be grounded.");
   p.addRequiredParam<Real>("penalty", "The constant multiplying the penalty term.");
+  p.addRequiredParam<UserObjectName>("data_provider", "The name of the UserObject that can provide some data to materials, bcs, etc.");
+  p.addRequiredCoupledVar("em", "The electron variable.");
+  p.addRequiredCoupledVar("ip", "The ion variable.");
   return p;
 }
 
 
 PenaltyCircuitPotential::PenaltyCircuitPotential(const InputParameters & parameters) :
-  IntegratedBC(parameters),
-  _current(getPostprocessorValue("current")),
+  NonlocalIntegratedBC(parameters),
+  _current_uo(getUserObject<CurrentDensityShapeSideUserObject>("current")),
+  _current(_current_uo.getIntegral()),
+  _current_jac(_current_uo.getJacobian()),
   _surface_potential(getParam<Real>("surface_potential")),
   _surface(getParam<std::string>("surface")),
-  _p(getParam<Real>("penalty"))
+  _p(getParam<Real>("penalty")),
+  _data(getUserObject<ProvideMobility>("data_provider")),
+  _var_dofs(_var.dofIndices()),
+  _em_id(coupled("em")),
+  _em_dofs(getVar("em", 0)->dofIndices()),
+  _ip_id(coupled("ip")),
+  _ip_dofs(getVar("ip", 0)->dofIndices())
 {
   if (_surface.compare("anode") == 0)
     _current_sign = -1.;
@@ -34,5 +45,33 @@ PenaltyCircuitPotential::computeQpResidual()
 Real
 PenaltyCircuitPotential::computeQpJacobian()
 {
-  return _test[_i][_qp] * _p * -1.;
+  return _test[_i][_qp] * _p * (-_phi[_j][_qp] + _current_sign * _current_jac[_var_dofs[_j]]);
+}
+
+Real
+PenaltyCircuitPotential::computeQpOffDiagJacobian(unsigned int jvar)
+{
+  if (jvar == _em_id)
+    return _test[_i][_qp] * _p * _current_sign * _current_jac[_em_dofs[_j]];
+
+  else if (jvar == _ip_id)
+    return _test[_i][_qp] * _p * _current_sign * _current_jac[_ip_dofs[_j]];
+
+  else
+    return 0;
+}
+
+Real
+PenaltyCircuitPotential::computeQpNonlocalJacobian(dof_id_type dof_index)
+{
+  return _test[_i][_qp] * _p * _current_sign * _current_jac[dof_index];
+}
+
+Real
+PenaltyCircuitPotential::computeQpNonlocalOffDiagJacobian(unsigned int jvar, dof_id_type dof_index)
+{
+  if (jvar == _em_id || jvar == _ip_id)
+    return _test[_i][_qp] * _p * _current_sign * _current_jac[dof_index];
+
+  return 0;
 }

--- a/tests/Schottky_emission/Example4/Input.i
+++ b/tests/Schottky_emission/Example4/Input.i
@@ -96,12 +96,12 @@ relaxTime = 50E-6 #s
 []
 
 [UserObjects]
-	[./current_density_user_object]
-		type = CurrentDensityShapeSideUserObject
-		u = tot_gas_current
-    boundary = left
-    execute_on = 'linear nonlinear'
-	[../]	
+    # 	[./current_density_user_object]
+    # 		type = CurrentDensityShapeSideUserObject
+    # 		u = tot_gas_current
+    # boundary = left
+    # execute_on = 'linear nonlinear'
+    # 	[../]
 	[./data_provider]
 		type = ProvideMobility
 		electrode_area = 5.02e-7 # Formerly 3.14e-6
@@ -523,22 +523,22 @@ relaxTime = 50E-6 #s
 #		position_units = ${dom0Scale}
 #	[../]
 
-	[./potential_left]
-    boundary = left
-    type = CurrentDensityShapeSideUserObject
-		variable = potential
-		
-		function = potential_bc_func
-		current_density = tot_gas_current
+    # 	[./potential_left]
+    # boundary = left
+    # type = CurrentDensityShapeSideUserObject
+    # 		variable = potential
 
-		ip = Arp
-		em = em
-		mean_en = mean_en
+    # 		function = potential_bc_func
+    # 		current_density = tot_gas_current
 
-		data_provider = data_provider
+    # 		ip = Arp
+    # 		em = em
+    # 		mean_en = mean_en
 
-		position_units = ${dom0Scale}
-	[../]
+    # 		data_provider = data_provider
+
+    # 		position_units = ${dom0Scale}
+    # 	[../]
 
 
 	[./potential_dirichlet_right]


### PR DESCRIPTION
You don't have to merge this unless you want to, but here's just some quick modifications I made to a pre-existing boundary condition to prepare it for use with CurrentDensityShapeSideUserObject. Should be an example more than anything else at this early stage.